### PR TITLE
Only update sync adapter instance if already null

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion '20.0.0'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
     defaultConfig {
         applicationId 'com.twitter.university.android.minisync'
         minSdkVersion 15
-        targetSdkVersion 19
+        targetSdkVersion 23
         versionCode 1
         versionName '1.0'
     }

--- a/app/src/main/java/com/twitter/university/android/minisync/SyncService.java
+++ b/app/src/main/java/com/twitter/university/android/minisync/SyncService.java
@@ -12,12 +12,18 @@ import android.util.Log;
 public class SyncService extends Service {
     private static final String ACTION_BIND_SYNC = "android.content.SyncAdapter";
 
-    private volatile SyncAdapter syncAdapter;
+    private static volatile SyncAdapter syncAdapter;
+
+    private static final Object syncAdapterLock = new Object();
 
     @Override
     public void onCreate() {
         super.onCreate();
-        syncAdapter = new SyncAdapter(getApplication(), true);
+        synchronized (syncAdapterLock) {
+            if (syncAdapter == null) {
+                syncAdapter = new SyncAdapter(getApplicationContext(), true);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
I was having trouble with code that requested syncs almost simultaneously. This change fixes it.

The docs also suggest in favor of adopting this new behavior. See http://developer.android.com/training/sync-adapters/creating-sync-adapter.html
